### PR TITLE
Dependabot fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    labels:
+      - "pip dependencies"


### PR DESCRIPTION
This should point dependabot to develop instead of master.
Note that this needs to be in master, branch is develop for convenience.