### PR TITLE
Fix gh action release

### DIFF
--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           conda create -n alphamap_pip_test python=3.8 -y
           conda activate alphamap_pip_test
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple "alphamap"
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple "alphamap[stable]"
           echo "TODO, this will run forever.."
           #alphamap
           conda deactivate
@@ -181,7 +181,7 @@ jobs:
         run: |
           conda create -n alphamap_pip_test python=3.8 -y
           conda activate alphamap_pip_test
-          pip install "alphamap"
+          pip install "alphamap[stable]"
           echo "TODO, this will run forever.."
           #alphamap
           conda deactivate

--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          miniconda-version: "latest"
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -135,10 +135,11 @@ jobs:
         run: |
           conda create -n alphamap python=3.8 -y
           pip install twine
+          pip install build
           conda activate alphamap
           rm -rf dist
           rm -rf build
-          python setup.py sdist bdist_wheel
+          python -m build
           twine check dist/*
           conda deactivate
       - name: Publish distribution to Test PyPI


### PR DESCRIPTION
-added miniconda-version: "latest" to fix macOS release issue
-used "build" instead of setup.py in the pip release
-add [stable] tag in tests