### PR TITLE
remove "env remove" command

### DIFF
--- a/misc/one_click_macos/create_installer_macos.sh
+++ b/misc/one_click_macos/create_installer_macos.sh
@@ -4,7 +4,6 @@ FILE=alphamap.pkg
 if test -f "$FILE"; then
   rm alphamap.pkg
 fi
-conda env remove -n alphamapinstaller
 conda create -n alphamapinstaller python=3.8 -y
 conda activate alphamapinstaller
 


### PR DESCRIPTION
A `conda env remove -n alphamapinstaller` in the macOS install script made problems. Removing it resulted in successful build of the draft release